### PR TITLE
Fix a crash of DataLoader

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 word2vec
 numpy
 scipy==1.1.0
-pillow
+pillow!=8.3.0
 lmdb
 torchfile
 scikit-learn


### PR DESCRIPTION
If you docker-build the Dockerfile with the current requirements.txt, test.py encounters https://github.com/pytorch/vision/issues/4146. Since it was fixed by https://github.com/pytorch/vision/pull/4148 but not released yet, the only fix we can do is to have the same exclusion.

We may also want to consider having a way to lock all the dependencies for better reproducibility, but I didn't do that in this PR for now.